### PR TITLE
feat(azure-devops): add PR review action tools (vote, comment, reply)

### DIFF
--- a/azure-devops/src/index.ts
+++ b/azure-devops/src/index.ts
@@ -40,6 +40,12 @@ import { getPRTestImpactTool } from "./tools/get-pr-test-impact";
 
 import { getRepositoryContextTool } from "./tools/get-repository-context";
 
+// Import PR review-action tools
+import { setPullRequestVoteTool } from "./tools/git-set-pr-vote";
+import { listPullRequestThreadsTool } from "./tools/git-list-pr-threads";
+import { addPullRequestCommentTool } from "./tools/git-add-pr-comment";
+import { replyPullRequestCommentTool } from "./tools/git-reply-pr-comment";
+
 // Create server instance
 const server = new McpServer({
     name: "azure-devops-mcp-server",
@@ -250,6 +256,35 @@ server.tool(
     getRepositoryContextTool.description,
     getRepositoryContextTool.parameters,
     getRepositoryContextTool.handler
+);
+
+// Register PR review-action tools (vote / comment / reply)
+server.tool(
+    setPullRequestVoteTool.name,
+    setPullRequestVoteTool.description,
+    setPullRequestVoteTool.parameters,
+    setPullRequestVoteTool.handler
+);
+
+server.tool(
+    listPullRequestThreadsTool.name,
+    listPullRequestThreadsTool.description,
+    listPullRequestThreadsTool.parameters,
+    listPullRequestThreadsTool.handler
+);
+
+server.tool(
+    addPullRequestCommentTool.name,
+    addPullRequestCommentTool.description,
+    addPullRequestCommentTool.parameters,
+    addPullRequestCommentTool.handler
+);
+
+server.tool(
+    replyPullRequestCommentTool.name,
+    replyPullRequestCommentTool.description,
+    replyPullRequestCommentTool.parameters,
+    replyPullRequestCommentTool.handler
 );
 
 // Start the server

--- a/azure-devops/src/tools/git-add-pr-comment.ts
+++ b/azure-devops/src/tools/git-add-pr-comment.ts
@@ -1,0 +1,161 @@
+import { z } from "zod";
+import { getGitApi } from "../utils/azure-devops-client";
+import * as GitInterfaces from "azure-devops-node-api/interfaces/GitInterfaces";
+
+const STATUS_MAP: Record<string, GitInterfaces.CommentThreadStatus> = {
+    active: GitInterfaces.CommentThreadStatus.Active,
+    fixed: GitInterfaces.CommentThreadStatus.Fixed,
+    "won't-fix": GitInterfaces.CommentThreadStatus.WontFix,
+    closed: GitInterfaces.CommentThreadStatus.Closed,
+    "by-design": GitInterfaces.CommentThreadStatus.ByDesign,
+    pending: GitInterfaces.CommentThreadStatus.Pending,
+};
+
+export const addPullRequestCommentTool = {
+    name: "git-add-pr-comment",
+    description: `
+        Adds a new comment thread to a pull request. The thread can be a general PR-level
+        comment (omit filePath) or an inline review comment anchored to a file/line range
+        in the new (right) version of the diff.
+
+        IMPORTANT — filePath format:
+        - Must be repo-root relative AND start with a leading '/'.
+        - Correct:   "/src/app.ts"
+        - Incorrect: "src/app.ts"  (Azure DevOps will reject or silently ignore the anchor)
+
+        Thread status values (controls how the comment appears in the PR review UI):
+        - "active":     Open / unresolved. Default for new feedback.
+        - "pending":    Draft visible only to the author until published; rarely needed.
+        - "fixed":      Resolved as fixed (typical "resolve" status after a code change).
+        - "closed":     Discussion ended without explicit resolution.
+        - "won't-fix":  Acknowledged but won't be addressed.
+        - "by-design":  Behavior is intentional; not a bug.
+
+        Parameters:
+        - organizationUrl: Azure DevOps organization URL
+        - project: Project name
+        - repositoryName: Repository name
+        - pullRequestId: Pull request ID
+        - content: The comment text (Markdown supported)
+        - status: Initial thread status (default "active")
+        - filePath: Optional file path starting with '/' to anchor the comment
+          (e.g. "/src/app.ts"). Required for inline comments.
+        - rightStartLine / rightStartColumn / rightEndLine / rightEndColumn: Optional
+          1-based line/column range in the right (new) version of the file. Provide at
+          least rightStartLine to create an inline review comment.
+    `,
+    parameters: {
+        organizationUrl: z.string().describe("Azure DevOps organization URL"),
+        project: z.string().describe("Project name"),
+        repositoryName: z.string().describe("Repository name"),
+        pullRequestId: z.number().int().describe("Pull request ID"),
+        content: z.string().describe("Comment content (Markdown supported)"),
+        status: z
+            .enum(["active", "fixed", "won't-fix", "closed", "by-design", "pending"])
+            .default("active")
+            .describe("Initial thread status"),
+        filePath: z.string().optional().describe("Optional file path (e.g. '/src/app.ts') to anchor the comment"),
+        rightStartLine: z.number().int().optional().describe("1-based start line in the right (new) file version"),
+        rightStartColumn: z.number().int().optional().describe("1-based start column in the right file version"),
+        rightEndLine: z.number().int().optional().describe("1-based end line in the right file version"),
+        rightEndColumn: z.number().int().optional().describe("1-based end column in the right file version"),
+    },
+    handler: async ({
+        organizationUrl,
+        project,
+        repositoryName,
+        pullRequestId,
+        content,
+        status,
+        filePath,
+        rightStartLine,
+        rightStartColumn,
+        rightEndLine,
+        rightEndColumn,
+    }: {
+        organizationUrl: string;
+        project: string;
+        repositoryName: string;
+        pullRequestId: number;
+        content: string;
+        status: keyof typeof STATUS_MAP;
+        filePath?: string;
+        rightStartLine?: number;
+        rightStartColumn?: number;
+        rightEndLine?: number;
+        rightEndColumn?: number;
+    }) => {
+        try {
+            const gitApi = await getGitApi(organizationUrl);
+
+            const repositories = await gitApi.getRepositories(project);
+            const repository = repositories.find(
+                (r) => r.name && r.name.toLowerCase() === repositoryName.toLowerCase()
+            );
+            if (!repository?.id) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Repository "${repositoryName}" not found in project "${project}".`,
+                    }],
+                };
+            }
+
+            const thread: GitInterfaces.GitPullRequestCommentThread = {
+                status: STATUS_MAP[status],
+                comments: [
+                    {
+                        parentCommentId: 0,
+                        content,
+                        commentType: GitInterfaces.CommentType.Text,
+                    },
+                ],
+            };
+
+            if (filePath) {
+                const startLine = rightStartLine ?? 1;
+                const endLine = rightEndLine ?? startLine;
+                const startCol = rightStartColumn ?? 1;
+                const endCol = rightEndColumn ?? Math.max(startCol, 1);
+                thread.threadContext = {
+                    filePath,
+                    rightFileStart: { line: startLine, offset: startCol },
+                    rightFileEnd: { line: endLine, offset: endCol },
+                };
+            }
+
+            const created = await gitApi.createThread(
+                thread,
+                repository.id,
+                pullRequestId,
+                project
+            );
+
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: JSON.stringify(
+                        {
+                            pullRequestId,
+                            threadId: created?.id,
+                            commentId: created?.comments?.[0]?.id,
+                            status: created?.status,
+                            filePath: created?.threadContext?.filePath ?? null,
+                            createdBy: created?.comments?.[0]?.author?.displayName,
+                        },
+                        null,
+                        2
+                    ),
+                }],
+            };
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: `Error adding pull request comment: ${msg}`,
+                }],
+            };
+        }
+    },
+};

--- a/azure-devops/src/tools/git-list-pr-threads.ts
+++ b/azure-devops/src/tools/git-list-pr-threads.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import { getGitApi } from "../utils/azure-devops-client";
+
+export const listPullRequestThreadsTool = {
+    name: "git-list-pr-threads",
+    description: `
+        Lists comment threads on a pull request, including each comment's id, author,
+        content, status, and any file/line context. Use this to discover threadIds for
+        replying with "git-reply-pr-comment".
+
+        Parameters:
+        - organizationUrl: Azure DevOps organization URL
+        - project: Project name
+        - repositoryName: Repository name
+        - pullRequestId: Pull request ID
+        - includeDeleted: Whether to include deleted threads/comments (default: false)
+    `,
+    parameters: {
+        organizationUrl: z.string().describe("Azure DevOps organization URL"),
+        project: z.string().describe("Project name"),
+        repositoryName: z.string().describe("Repository name"),
+        pullRequestId: z.number().int().describe("Pull request ID"),
+        includeDeleted: z.boolean().default(false).describe("Include deleted threads/comments"),
+    },
+    handler: async ({
+        organizationUrl,
+        project,
+        repositoryName,
+        pullRequestId,
+        includeDeleted,
+    }: {
+        organizationUrl: string;
+        project: string;
+        repositoryName: string;
+        pullRequestId: number;
+        includeDeleted: boolean;
+    }) => {
+        try {
+            const gitApi = await getGitApi(organizationUrl);
+
+            const repositories = await gitApi.getRepositories(project);
+            const repository = repositories.find(
+                (r) => r.name && r.name.toLowerCase() === repositoryName.toLowerCase()
+            );
+            if (!repository?.id) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Repository "${repositoryName}" not found in project "${project}".`,
+                    }],
+                };
+            }
+
+            const threads = await gitApi.getThreads(repository.id, pullRequestId, project);
+
+            const simplified = (threads ?? [])
+                .filter((t) => includeDeleted || !t.isDeleted)
+                .map((t) => ({
+                    threadId: t.id,
+                    status: t.status,
+                    publishedDate: t.publishedDate,
+                    lastUpdatedDate: t.lastUpdatedDate,
+                    isDeleted: t.isDeleted,
+                    threadContext: t.threadContext
+                        ? {
+                            filePath: t.threadContext.filePath,
+                            rightFileStart: t.threadContext.rightFileStart,
+                            rightFileEnd: t.threadContext.rightFileEnd,
+                            leftFileStart: t.threadContext.leftFileStart,
+                            leftFileEnd: t.threadContext.leftFileEnd,
+                        }
+                        : null,
+                    comments: (t.comments ?? [])
+                        .filter((c) => includeDeleted || !c.isDeleted)
+                        .map((c) => ({
+                            commentId: c.id,
+                            parentCommentId: c.parentCommentId,
+                            author: c.author?.displayName,
+                            authorId: c.author?.id,
+                            commentType: c.commentType,
+                            publishedDate: c.publishedDate,
+                            lastUpdatedDate: c.lastUpdatedDate,
+                            isDeleted: c.isDeleted,
+                            content: c.content,
+                        })),
+                }));
+
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: JSON.stringify(
+                        { pullRequestId, threadCount: simplified.length, threads: simplified },
+                        null,
+                        2
+                    ),
+                }],
+            };
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: `Error listing pull request threads: ${msg}`,
+                }],
+            };
+        }
+    },
+};

--- a/azure-devops/src/tools/git-reply-pr-comment.ts
+++ b/azure-devops/src/tools/git-reply-pr-comment.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import { getGitApi } from "../utils/azure-devops-client";
+import * as GitInterfaces from "azure-devops-node-api/interfaces/GitInterfaces";
+
+const STATUS_MAP: Record<string, GitInterfaces.CommentThreadStatus> = {
+    active: GitInterfaces.CommentThreadStatus.Active,
+    fixed: GitInterfaces.CommentThreadStatus.Fixed,
+    "won't-fix": GitInterfaces.CommentThreadStatus.WontFix,
+    closed: GitInterfaces.CommentThreadStatus.Closed,
+    "by-design": GitInterfaces.CommentThreadStatus.ByDesign,
+    pending: GitInterfaces.CommentThreadStatus.Pending,
+};
+
+export const replyPullRequestCommentTool = {
+    name: "git-reply-pr-comment",
+    description: `
+        Replies to an existing comment thread on a pull request, optionally updating the
+        thread's status (e.g. resolve to "fixed" or "closed").
+
+        Always call "git-list-pr-threads" first to discover the threadId. Note that Azure
+        DevOps renders thread comments as a flat list, so parentCommentId is largely
+        cosmetic — leaving it at 0 (thread root) is correct in almost all cases.
+
+        updateStatus values (use to resolve or change a thread's state in the same call):
+        - "active":     Open / unresolved
+        - "fixed":      Resolved as fixed (typical "resolve" after the author addressed feedback)
+        - "closed":     Discussion ended without explicit resolution
+        - "won't-fix":  Acknowledged but won't be addressed
+        - "by-design":  Behavior is intentional
+        - "pending":    Draft / not yet published
+
+        Parameters:
+        - organizationUrl: Azure DevOps organization URL
+        - project: Project name
+        - repositoryName: Repository name
+        - pullRequestId: Pull request ID
+        - threadId: ID of the existing comment thread to reply to (from git-list-pr-threads)
+        - content: Reply text (Markdown supported)
+        - parentCommentId: Optional parent commentId within the thread (default: 0 = thread root).
+          Leave at 0 unless you have a specific reason; comments render flat regardless.
+        - updateStatus: Optional new thread status to set after replying.
+    `,
+    parameters: {
+        organizationUrl: z.string().describe("Azure DevOps organization URL"),
+        project: z.string().describe("Project name"),
+        repositoryName: z.string().describe("Repository name"),
+        pullRequestId: z.number().int().describe("Pull request ID"),
+        threadId: z.number().int().describe("Existing thread ID"),
+        content: z.string().describe("Reply content (Markdown supported)"),
+        parentCommentId: z.number().int().default(0).describe("Parent comment id within the thread (0 = root)"),
+        updateStatus: z
+            .enum(["active", "fixed", "won't-fix", "closed", "by-design", "pending"])
+            .optional()
+            .describe("Optional new status for the thread after replying"),
+    },
+    handler: async ({
+        organizationUrl,
+        project,
+        repositoryName,
+        pullRequestId,
+        threadId,
+        content,
+        parentCommentId,
+        updateStatus,
+    }: {
+        organizationUrl: string;
+        project: string;
+        repositoryName: string;
+        pullRequestId: number;
+        threadId: number;
+        content: string;
+        parentCommentId: number;
+        updateStatus?: keyof typeof STATUS_MAP;
+    }) => {
+        try {
+            const gitApi = await getGitApi(organizationUrl);
+
+            const repositories = await gitApi.getRepositories(project);
+            const repository = repositories.find(
+                (r) => r.name && r.name.toLowerCase() === repositoryName.toLowerCase()
+            );
+            if (!repository?.id) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Repository "${repositoryName}" not found in project "${project}".`,
+                    }],
+                };
+            }
+
+            const createdComment = await gitApi.createComment(
+                {
+                    parentCommentId,
+                    content,
+                    commentType: GitInterfaces.CommentType.Text,
+                },
+                repository.id,
+                pullRequestId,
+                threadId,
+                project
+            );
+
+            let updatedStatusValue: GitInterfaces.CommentThreadStatus | undefined;
+            if (updateStatus) {
+                const updated = await gitApi.updateThread(
+                    { status: STATUS_MAP[updateStatus] },
+                    repository.id,
+                    pullRequestId,
+                    threadId,
+                    project
+                );
+                updatedStatusValue = updated?.status;
+            }
+
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: JSON.stringify(
+                        {
+                            pullRequestId,
+                            threadId,
+                            commentId: createdComment?.id,
+                            parentCommentId: createdComment?.parentCommentId,
+                            author: createdComment?.author?.displayName,
+                            publishedDate: createdComment?.publishedDate,
+                            updatedThreadStatus: updateStatus
+                                ? { name: updateStatus, value: updatedStatusValue }
+                                : null,
+                        },
+                        null,
+                        2
+                    ),
+                }],
+            };
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: `Error replying to pull request comment: ${msg}`,
+                }],
+            };
+        }
+    },
+};

--- a/azure-devops/src/tools/git-set-pr-vote.ts
+++ b/azure-devops/src/tools/git-set-pr-vote.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+import { getGitApi, getAuthenticatedUserId } from "../utils/azure-devops-client";
+
+// Azure DevOps reviewer vote values
+const VOTE_VALUES = {
+    approve: 10,
+    "approve-with-suggestions": 5,
+    reset: 0,
+    "wait-for-author": -5,
+    reject: -10,
+} as const;
+
+type VoteName = keyof typeof VOTE_VALUES;
+
+export const setPullRequestVoteTool = {
+    name: "git-set-pr-vote",
+    description: `
+        Casts (or updates) the calling user's review vote on a pull request. This is the
+        programmatic equivalent of the Approve / Reject buttons in the Azure DevOps web UI
+        and is how an AI reviewer signs off on or declines a PR.
+
+        Vote values:
+        - "approve" (10): Sign off. Counts toward required-reviewer policies and can
+          trigger auto-complete if all other branch policies are satisfied.
+        - "approve-with-suggestions" (5): Approve, but flag non-blocking suggestions.
+        - "reset" (0): Clear any previous vote (return to "no vote").
+        - "wait-for-author" (-5): Soft block — author should address feedback. Does not
+          decline the PR.
+        - "reject" (-10): Decline the PR. Hard block; prevents completion until reset.
+
+        Typical AI-reviewer workflow:
+          1) get-pr-basic-info       — read metadata, existing reviewers, current votes
+          2) get-pr-code-diffs       — inspect the actual changes
+          3) git-add-pr-comment      — leave inline review feedback (optional)
+          4) git-set-pr-vote         — cast approve / reject / wait-for-author
+
+        Side effects: Voting notifies the PR's subscribers and is evaluated against branch
+        policies immediately. An "approve" that satisfies the last required reviewer can
+        auto-complete and merge the PR if auto-complete is enabled.
+
+        Parameters:
+        - organizationUrl: Azure DevOps organization URL (e.g. https://dev.azure.com/fabrikam)
+        - project: Project name containing the repository
+        - repositoryName: Name of the Git repository containing the pull request
+        - pullRequestId: Numeric ID of the pull request to vote on
+        - vote: One of "approve" | "approve-with-suggestions" | "reset" | "wait-for-author" | "reject"
+        - reviewerId: Optional GUID of the reviewer to set the vote for. Defaults to the
+          authenticated caller. Specify another identity only if you have permission to
+          vote on their behalf (rare; typically used by service accounts).
+    `,
+    parameters: {
+        organizationUrl: z.string().describe("Azure DevOps organization URL"),
+        project: z.string().describe("Project name"),
+        repositoryName: z.string().describe("Repository name"),
+        pullRequestId: z.number().int().describe("Pull request ID"),
+        vote: z
+            .enum([
+                "approve",
+                "approve-with-suggestions",
+                "reset",
+                "wait-for-author",
+                "reject",
+            ])
+            .describe("Vote to cast"),
+        reviewerId: z
+            .string()
+            .optional()
+            .describe("Optional reviewer identity GUID. Defaults to the authenticated user."),
+    },
+    handler: async ({
+        organizationUrl,
+        project,
+        repositoryName,
+        pullRequestId,
+        vote,
+        reviewerId,
+    }: {
+        organizationUrl: string;
+        project: string;
+        repositoryName: string;
+        pullRequestId: number;
+        vote: VoteName;
+        reviewerId?: string;
+    }) => {
+        try {
+            const gitApi = await getGitApi(organizationUrl);
+
+            // Resolve repository ID
+            const repositories = await gitApi.getRepositories(project);
+            const repository = repositories.find(
+                (r) => r.name && r.name.toLowerCase() === repositoryName.toLowerCase()
+            );
+            if (!repository?.id) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Repository "${repositoryName}" not found in project "${project}".`,
+                    }],
+                };
+            }
+
+            const resolvedReviewerId =
+                reviewerId ?? (await getAuthenticatedUserId(organizationUrl));
+
+            const voteValue = VOTE_VALUES[vote];
+
+            const result = await gitApi.createPullRequestReviewer(
+                { vote: voteValue, id: resolvedReviewerId },
+                repository.id,
+                pullRequestId,
+                resolvedReviewerId,
+                project
+            );
+
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: JSON.stringify(
+                        {
+                            pullRequestId,
+                            repository: repositoryName,
+                            project,
+                            reviewerId: resolvedReviewerId,
+                            reviewerDisplayName: result?.displayName,
+                            voteName: vote,
+                            voteValue,
+                            isRequired: result?.isRequired ?? false,
+                        },
+                        null,
+                        2
+                    ),
+                }],
+            };
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: `Error setting pull request vote: ${msg}`,
+                }],
+            };
+        }
+    },
+};

--- a/azure-devops/src/utils/azure-devops-client.ts
+++ b/azure-devops/src/utils/azure-devops-client.ts
@@ -49,6 +49,21 @@ export async function getReleaseApi(organizationUrl: string): Promise<ReleaseApi
     return await connection.getReleaseApi();
 }
 
+/**
+ * Returns the unique identifier (GUID) of the user the access token is issued to.
+ * Useful when an Azure DevOps API call requires a reviewerId / identity reference
+ * (for example, casting a vote on a pull request) and the caller wants to act as themselves.
+ */
+export async function getAuthenticatedUserId(organizationUrl: string): Promise<string> {
+    const connection = await getAzureDevOpsConnection(organizationUrl);
+    const connectionData = await connection.connect();
+    const userId = connectionData?.authenticatedUser?.id;
+    if (!userId) {
+        throw new Error("Unable to determine authenticated user id from Azure DevOps connection.");
+    }
+    return userId;
+}
+
 export async function getPipelinesApi(organizationUrl: string): Promise<PipelinesApi> {
     const connection = await getAzureDevOpsConnection(organizationUrl);
     return await connection.getPipelinesApi();


### PR DESCRIPTION
## Summary

Adds four new MCP tools to the `azure-devops` server so an AI reviewer can fully act on Azure DevOps pull requests — not just read them. Previously the server could surface PR metadata, diffs, and reviewer votes, but had no way to **sign off**, **decline**, or **participate in review discussions**.

## New tools

| Tool | Purpose |
|---|---|
| `git-set-pr-vote` | Cast/update a reviewer vote: `approve`, `approve-with-suggestions`, `reset`, `wait-for-author`, `reject` (decline). Defaults reviewer to the authenticated caller. |
| `git-list-pr-threads` | Enumerate comment threads on a PR with `threadId`, comments, status, and file/line context. Use to discover threads to reply to. |
| `git-add-pr-comment` | Create a new thread — either a PR-level comment or an inline review comment anchored to a file path + line range in the right (new) file version. |
| `git-reply-pr-comment` | Reply to an existing thread, optionally updating its status (e.g. resolve to `fixed` / `closed`). |

## Supporting changes

- `azure-devops-client.ts`: new `getAuthenticatedUserId()` helper using `connection.connect()` so `git-set-pr-vote` can default `reviewerId` to the calling identity.
- `index.ts`: imports and registers all four new tools.

## Vote value mapping

Standard Azure DevOps reviewer vote constants used with `gitApi.createPullRequestReviewer`:

| Name | Value | Meaning |
|---|---|---|
| approve | 10 | Sign off; can satisfy required-reviewer policies |
| approve-with-suggestions | 5 | Approve with non-blocking suggestions |
| reset | 0 | Clear prior vote |
| wait-for-author | -5 | Soft block, awaiting author changes |
| reject | -10 | Decline; hard block until reset |

## Documentation for AI consumers

Each tool's `description` field includes:
- Per-enum semantic glosses (vote values, thread statuses)
- Side-effect notes (e.g. an approve can trigger auto-complete)
- A typical 4-step reviewer workflow (`get-pr-basic-info` → `get-pr-code-diffs` → `git-add-pr-comment` → `git-set-pr-vote`)
- The `filePath must start with /` gotcha for inline comments
- Note that ADO renders comments flat, so `parentCommentId=0` is almost always correct

## Verification

- VS Code TypeScript service reports no errors across all changed/added files.
- Package `node_modules` not installed locally, so `tsc` from CLI was not run; intended to be validated by CI / consumer install.

## Files changed

- `azure-devops/src/index.ts` (modified)
- `azure-devops/src/utils/azure-devops-client.ts` (modified)
- `azure-devops/src/tools/git-set-pr-vote.ts` (new)
- `azure-devops/src/tools/git-list-pr-threads.ts` (new)
- `azure-devops/src/tools/git-add-pr-comment.ts` (new)
- `azure-devops/src/tools/git-reply-pr-comment.ts` (new)
