### PR TITLE
fix: drop removed McpServer 'capabilities' field; add @azure/identity-broker dep

### DIFF
--- a/api-tools/src/index.ts
+++ b/api-tools/src/index.ts
@@ -14,10 +14,6 @@ async function main() {
       name: process.env.MCP_SERVER_NAME || "api-tools-mcp-server",
       description: "API Tools MCP Server for API integration",
       version: process.env.MCP_SERVER_VERSION || "1.0.0",
-      capabilities: {
-        resources: {},
-        tools: {},
-      },
     });
 
     // Register the API call tool

--- a/azure-devops/src/index.ts
+++ b/azure-devops/src/index.ts
@@ -51,10 +51,6 @@ const server = new McpServer({
     name: "azure-devops-mcp-server",
     description: "Azure DevOps MCP Server",
     version: "1.0.0",
-    capabilities: {
-        resources: {},
-        tools: {},
-    },
 });
 
 // Register tools

--- a/delta-table-server/src/index.ts
+++ b/delta-table-server/src/index.ts
@@ -12,10 +12,6 @@ import { createDeltaTableTool } from "./tools/createDeltaTable.js";
 const server = new McpServer({
   name: "delta-table-server",
   version: "1.0.0",
-  capabilities: {
-    resources: {},
-    tools: {},
-  },
 });
 
 // Register simplified tools

--- a/kusto-server/package.json
+++ b/kusto-server/package.json
@@ -22,6 +22,8 @@
     "token": "npx vsts-npm-auth -config .npmrc"
   },
   "dependencies": {
+    "@azure/identity": "^4.0.0",
+    "@azure/identity-broker": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.13.2",
     "azure-kusto-data": "^7.0.0",
     "azure-kusto-ingest": "^7.0.0",

--- a/kusto-server/src/index.ts
+++ b/kusto-server/src/index.ts
@@ -12,10 +12,6 @@ async function main() {
       name: process.env.MCP_SERVER_NAME || "kusto-mcp-server",
       description: "Kusto MCP Server for Azure Data Explorer integration",
       version: process.env.MCP_SERVER_VERSION || "1.0.0",
-      capabilities: {
-        resources: {},
-        tools: {},
-      },
     });
 
     server.tool(

--- a/pdf-tools/src/index.ts
+++ b/pdf-tools/src/index.ts
@@ -11,10 +11,6 @@ async function main() {
       name: process.env.MCP_SERVER_NAME || "pdf-tools-mcp-server",
       description: "PDF Tools MCP Server for document processing and analysis",
       version: process.env.MCP_SERVER_VERSION || "1.0.0",
-      capabilities: {
-        resources: {},
-        tools: {},
-      },
     });
 
     server.tool(

--- a/synapse-server/src/index.ts
+++ b/synapse-server/src/index.ts
@@ -11,10 +11,6 @@ async function main() {
       name: process.env.MCP_SERVER_NAME || "synapse-mcp-server",
       description: "Azure Synapse MCP Server for ADLS Gen2 and pipeline operations",
       version: process.env.MCP_SERVER_VERSION || "1.0.0",
-      capabilities: {
-        resources: {},
-        tools: {},
-      },
     });
 
     // Synapse Pipeline Tools


### PR DESCRIPTION
## Summary

Fixes the `1.0.42` release workflow ([failed run](https://github.com/adityavaish/mcp-apps/actions/runs/24939421184)) by addressing two breakages.

### 1. `McpServer` `capabilities` field removed in SDK update

`@modelcontextprotocol/sdk` no longer accepts `capabilities` on the `McpServer` constructor. TypeScript compile error:

```
error TS2353: Object literal may only specify known properties, and 'capabilities'
does not exist in type '{ version: string; name: string; ... }'
```

Removed the `capabilities: { resources: {}, tools: {} }` block from every package's `src/index.ts`:

- `pdf-tools/src/index.ts`
- `delta-table-server/src/index.ts`
- `kusto-server/src/index.ts`
- `api-tools/src/index.ts`
- `synapse-server/src/index.ts`
- `azure-devops/src/index.ts`

Tools and resources are still registered via `server.tool(...)` calls; the constructor field was redundant.

### 2. `kusto-server` missing `@azure/identity-broker` (and `@azure/identity`)

```
error TS2307: Cannot find module '@azure/identity-broker' or its corresponding type declarations.
```

`kusto-server/src/services/kustoService.ts` imports `nativeBrokerPlugin` from `@azure/identity-broker` and `InteractiveBrowserCredential` / `useIdentityPlugin` from `@azure/identity`, but neither was declared in `package.json` (relying on a transitive that no longer resolves at install time). Added both as explicit dependencies:

```json
"@azure/identity": "^4.0.0",
"@azure/identity-broker": "^1.4.0"
```

## Verification

- All six modified `index.ts` files type-check cleanly in the workspace TypeScript service (no errors).
- Matches the failure modes reported in the 1.0.42 workflow logs across `pdf-tools`, `kusto-server`, `azure-devops`, `api-tools`, etc.

## Follow-up

After merging, cut a new release tag (e.g. `1.0.43`) to re-trigger the publish workflow.
