### PR TITLE
ci: add workflow_dispatch + PR/push triggers; gate publish to release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,11 @@ name: Node.js Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   build:
@@ -29,6 +34,7 @@ jobs:
 
   publish-npm:
     needs: build
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Allows the `Node.js Package` workflow to run on every PR to `main`, on push to `main`, and on demand via the Actions UI / `gh workflow run`. Previously it was triggered only by `release: created`, which meant breakages (like the `1.0.42` release) were only discovered after tagging.

The `publish-npm` job is gated with `if: github.event_name == 'release'` so it continues to publish to npm only for real GitHub Releases — PR/push/dispatch runs are build-only validation.

## Diff

```yaml
on:
  release:
    types: [created]
  workflow_dispatch:        # new
  pull_request:             # new
    branches: [main]
  push:                     # new
    branches: [main]
```

```yaml
publish-npm:
  needs: build
  if: github.event_name == 'release'   # new
  runs-on: ubuntu-latest
```

## Effect

| Trigger | `build` job | `publish-npm` job |
|---|---|---|
| GitHub Release created | ✅ | ✅ |
| PR to `main` | ✅ | skipped |
| Push to `main` (post-merge) | ✅ | skipped |
| Manual "Run workflow" / `gh workflow run` | ✅ | skipped |

## How to trigger manually after merge

```bash
gh workflow run "Node.js Package" --ref main
```

…or use the **Run workflow** button under the Actions tab.

## Files changed

- `.github/workflows/npm-publish.yml`
