### PR TITLE
ci: allow npm version --allow-same-version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set package version from GitHub release
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
-          npm version --no-git-tag-version "$VERSION"
+          npm version --no-git-tag-version --allow-same-version "$VERSION"
         working-directory: ${{ matrix.package }}
       - run: npm publish
         working-directory: ${{ matrix.package }}


### PR DESCRIPTION
Fixes the 1.0.44 publish failure where azure-devops and kusto-server packages already had package.json versions matching the release tag, causing npm version to exit 1.